### PR TITLE
Fetch user details after login.

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -5,29 +5,29 @@ PODS:
     - ISO8601DateFormatter
     - LVTwitterOAuthClient
     - NSURL+QueryDictionary
-  - ISO8601DateFormatter (0.7)
+  - ISO8601DateFormatter (0.8)
   - Keys (1.0.0)
   - LVTwitterOAuthClient (0.3.0):
     - OAuthCore
-  - Nimble (3.0.0)
+  - Nimble (4.1.0)
   - NSData+Base64 (1.0.0)
-  - NSURL+QueryDictionary (1.1.0)
+  - NSURL+QueryDictionary (1.2.0)
   - OAuthCore (0.0.1):
     - NSData+Base64
-  - OHHTTPStubs (4.6.0):
-    - OHHTTPStubs/Default (= 4.6.0)
-  - OHHTTPStubs/Core (4.6.0)
-  - OHHTTPStubs/Default (4.6.0):
+  - OHHTTPStubs (5.2.0):
+    - OHHTTPStubs/Default (= 5.2.0)
+  - OHHTTPStubs/Core (5.2.0)
+  - OHHTTPStubs/Default (5.2.0):
     - OHHTTPStubs/Core
     - OHHTTPStubs/JSON
     - OHHTTPStubs/NSURLSession
     - OHHTTPStubs/OHPathHelpers
-  - OHHTTPStubs/JSON (4.6.0):
+  - OHHTTPStubs/JSON (5.2.0):
     - OHHTTPStubs/Core
-  - OHHTTPStubs/NSURLSession (4.6.0):
+  - OHHTTPStubs/NSURLSession (5.2.0):
     - OHHTTPStubs/Core
-  - OHHTTPStubs/OHPathHelpers (4.6.0)
-  - Quick (0.8.0)
+  - OHHTTPStubs/OHPathHelpers (5.2.0)
+  - Quick (0.9.3)
 
 DEPENDENCIES:
   - Artsy+Authentication (from `../`)
@@ -44,14 +44,14 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Artsy+Authentication: 3bf11ceca61c52e9e31490535bf5798f625406fa
-  ISO8601DateFormatter: ab926648eebe497f4d167c0fd083992f959f1274
+  ISO8601DateFormatter: 4551b6ce4f83185425f583b0b3feb3c7b59b942c
   Keys: 7d2ff6ff42f6903358267ce56e9392f83c31acfe
   LVTwitterOAuthClient: 058199e43af92c0b99332332fa26d2229c59f04d
-  Nimble: 4c353d43735b38b545cbb4cb91504588eb5de926
+  Nimble: 97a0a4cae5124c117115634b2d055d8c97d0af19
   NSData+Base64: 4e84902c4db907a15673474677e57763ef3903e4
-  NSURL+QueryDictionary: dd0a5fec689a9b4780b6fa0e0225c01ca3ea653e
+  NSURL+QueryDictionary: bae616404e2adf6409d3d5c02a093cbf44c8a236
   OAuthCore: 43dce261db846a1fe20234d95654257e00e78581
-  OHHTTPStubs: cb1aefbbeb4de4e741644455d4b945538e5248a2
-  Quick: 563d0f6ec5f72e394645adb377708639b7dd38ab
+  OHHTTPStubs: 29ae105797c3410112d10b217c8b7a55aab616b2
+  Quick: 13a2a2b19a5d8e3ed4fd0c36ee46597fd77ebf71
 
 COCOAPODS: 0.39.0

--- a/Pod/Classes/ArtsyAuthentication.h
+++ b/Pod/Classes/ArtsyAuthentication.h
@@ -10,20 +10,32 @@ typedef enum ArtsyErrorCode {
 @class ArtsyToken, ArtsyAuthenticationRouter;
 
 typedef void (^ArtsyAuthenticationCallback)(ArtsyToken *token, NSError *error);
+typedef void (^ArtsyAuthenticationWithUserDetailsCallback)(ArtsyToken *token, NSDictionary *userDetails, NSError *error);
 
 @interface ArtsyAuthentication : NSObject
 
 /// Create an authentication object
-- (instancetype)initWithClientID:(NSString *)clientID clientSecret:(NSString *)clientSecret NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithClientID:(NSString *)clientID
+                    clientSecret:(NSString *)clientSecret NS_DESIGNATED_INITIALIZER;
 
 /// Gets a week long trial user token, nil if network errors
-- (void)getWeekLongXAppTrialToken:(void (^)(ArtsyToken *token, NSError *error))completion;
+- (void)getWeekLongXAppTrialToken:(ArtsyAuthenticationCallback)completion;
 
 /// Gets a 35 year-long authenticated token, nil if network errors
-- (void)logInWithEmail:(NSString *)email password:(NSString *)password completion:(ArtsyAuthenticationCallback)completion;
+- (void)logInWithEmail:(NSString *)email
+              password:(NSString *)password
+            completion:(ArtsyAuthenticationCallback)completion;
+
+/// Gets a 35 year-long authenticated token, nil if network errors, and in addition fetches the user’s details
+- (void)logInAndFetchUserDetailsWithEmail:(NSString *)email
+                                 password:(NSString *)password
+                               completion:(ArtsyAuthenticationWithUserDetailsCallback)completion;
 
 /// Creates a new user, or fails
-- (void)createUserWithEmail:(NSString *)email name:(NSString *)name password:(NSString *)password completion:(void (^)(NSDictionary *newUserDictionary, NSError *error))completion;
+- (void)createUserWithEmail:(NSString *)email
+                       name:(NSString *)name
+                   password:(NSString *)password
+                 completion:(void (^)(NSDictionary *newUserDictionary, NSError *error))completion;
 
 /// Clears any user auth token from the router.
 - (void)logout;

--- a/Pod/Classes/ArtsyAuthentication.m
+++ b/Pod/Classes/ArtsyAuthentication.m
@@ -19,7 +19,9 @@ NSString* const ArtsyAuthenticationErrorDomain = @"ArtsyAuthenticationErrorDomai
 
 @implementation ArtsyAuthentication
 
-- (instancetype)initWithClientID:(NSString *)clientID clientSecret:(NSString *)clientSecret {
+- (instancetype)initWithClientID:(NSString *)clientID
+                    clientSecret:(NSString *)clientSecret;
+{
     self = [super init];
     if (!self) return nil;
 
@@ -31,11 +33,12 @@ NSString* const ArtsyAuthenticationErrorDomain = @"ArtsyAuthenticationErrorDomai
 
 #pragma mark - Public API
 
-- (void)getWeekLongXAppTrialToken:(void (^)(ArtsyToken *token, NSError *error))completion {
+- (void)getWeekLongXAppTrialToken:(ArtsyAuthenticationCallback)completion;
+{
     __weak __typeof(self) weakSelf = self;
 
     NSURLRequest *request = [self.router requestForXapp];
-    [self.networkOperator JSONTaskWithRequest:request success:^(NSURLRequest *request, NSHTTPURLResponse *response, id JSON) {
+    [self.networkOperator JSONTaskWithRequest:request success:^(NSURLRequest *_, NSHTTPURLResponse *__, id JSON) {
         __strong __typeof(weakSelf) strongSelf = weakSelf;
 
         NSDate *date = [[[ISO8601DateFormatter alloc] init] dateFromString:JSON[@"expires_in"]];
@@ -44,52 +47,91 @@ NSString* const ArtsyAuthenticationErrorDomain = @"ArtsyAuthenticationErrorDomai
         strongSelf.router.xappToken = token;
 
         completion(token, nil);
-    } failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON) {
+    } failure:^(NSURLRequest *_, NSHTTPURLResponse *response, NSError *error, id JSON) {
         __strong __typeof(weakSelf) strongSelf = weakSelf;
 
-        [strongSelf findErrorsInResponse:(NSHTTPURLResponse *)response error:&error dict:JSON];
+        [strongSelf findErrorsInResponse:response error:&error dict:JSON];
         completion(JSON, error);
     }];
 }
 
-- (void)logInWithEmail:(NSString *)email password:(NSString *)password completion:(ArtsyAuthenticationCallback)completion {
+- (void)logInWithEmail:(NSString *)email
+              password:(NSString *)password
+            completion:(ArtsyAuthenticationCallback)completion;
+{
     __weak __typeof(self) weakSelf = self;
 
     NSURLRequest *request = [self.router requestForAuthWithEmail:email password:password];
-    [self.networkOperator JSONTaskWithRequest:request success:^(NSURLRequest *request, NSHTTPURLResponse *response, id JSON) {
+    [self.networkOperator JSONTaskWithRequest:request success:^(NSURLRequest *_, NSHTTPURLResponse *__, id JSON) {
         __strong __typeof(weakSelf) strongSelf = weakSelf;
 
         NSDate *date = [[[ISO8601DateFormatter alloc] init] dateFromString:JSON[@"expires_in"]];
         ArtsyToken *token = [[ArtsyToken alloc] initWithToken:JSON[ArtsyOAuthTokenKey] expirationDate:date];
 
         [strongSelf callback:token error:nil completion:completion];
-    } failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON) {
+    } failure:^(NSURLRequest *_, NSHTTPURLResponse *response, NSError *error, id JSON) {
         __strong __typeof(weakSelf) strongSelf = weakSelf;
-        [strongSelf findErrorsInResponse:(NSHTTPURLResponse *)response error:&error dict:JSON];
+
+        [strongSelf findErrorsInResponse:response error:&error dict:JSON];
         [strongSelf callback:nil error:error completion:completion];
     }];
 }
 
-- (void)createUserWithEmail:(NSString *)email name:(NSString *)name password:(NSString *)password completion:(void (^)(NSDictionary *newUserDictionary, NSError *error))completion {
+- (void)logInAndFetchUserDetailsWithEmail:(NSString *)email
+                                 password:(NSString *)password
+                               completion:(ArtsyAuthenticationWithUserDetailsCallback)completion;
+{
+    __weak __typeof(self) weakSelf = self;
+
+    [self logInWithEmail:email password:password completion:^(ArtsyToken *token, NSError *error) {
+        if (error) {
+            completion(token, nil, error);
+        } else {
+            __strong __typeof(weakSelf) strongSelf = weakSelf;
+
+            if (strongSelf) {
+              NSURLRequest *request = [strongSelf.router requestForUserDetails];
+              [strongSelf.networkOperator JSONTaskWithRequest:request success:^(NSURLRequest *_, NSHTTPURLResponse *__, id JSON) {
+                completion(token, JSON, nil);
+              } failure:^(NSURLRequest *_, NSHTTPURLResponse *response, NSError *error, id JSON) {
+                [weakSelf findErrorsInResponse:response error:&error dict:JSON];
+                completion(token, JSON, error);
+              }];
+            }
+        }
+    }];
+}
+
+- (void)createUserWithEmail:(NSString *)email
+                       name:(NSString *)name
+                   password:(NSString *)password
+                 completion:(void (^)(NSDictionary *newUserDictionary, NSError *error))completion;
+{
+    __weak __typeof(self) weakSelf = self;
+
     NSURLRequest *request = [self.router requestForCreateNewUserwithEmail:email name:name password:password];
-    [self.networkOperator JSONTaskWithRequest:request success:^(NSURLRequest *request, NSHTTPURLResponse *response, id JSON) {
+    [self.networkOperator JSONTaskWithRequest:request success:^(NSURLRequest *_, NSHTTPURLResponse *__, id JSON) {
         completion(JSON, nil);
-    } failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON) {
-        [self findErrorsInResponse:(NSHTTPURLResponse *)response error:&error dict:JSON];
+    } failure:^(NSURLRequest *_, NSHTTPURLResponse *response, NSError *error, id JSON) {
+        [weakSelf findErrorsInResponse:response error:&error dict:JSON];
         completion(JSON, error);
     }];
 }
 
 #pragma mark - Request Management
 
-- (void)findErrorsInResponse:(NSHTTPURLResponse *)response error:(NSError **)error dict:(NSDictionary *)dict {
+- (void)findErrorsInResponse:(NSHTTPURLResponse *)response
+                       error:(NSError **)error
+                        dict:(NSDictionary *)dict;
+{
     if (*error) return;
     if (response.statusCode != 500) {
         *error = [NSError errorWithDomain:@"net.artsy" code:response.statusCode userInfo:dict];
     }
 }
 
-- (void)logout {
+- (void)logout;
+{
     self.router.authToken = nil;
 }
 

--- a/Pod/Classes/ArtsyAuthenticationRouter.h
+++ b/Pod/Classes/ArtsyAuthenticationRouter.h
@@ -14,6 +14,9 @@
 /// Typical Artsy artsy log in
 - (NSURLRequest *)requestForAuthWithEmail:(NSString *)email password:(NSString *)password;
 
+/// Details about user
+- (NSURLRequest *)requestForUserDetails;
+
 /// Artsy new user
 - (NSURLRequest *)requestForCreateNewUserwithEmail:(NSString *)email name:(NSString *)name password:(NSString *)password;
 

--- a/Pod/Classes/ArtsyAuthenticationRouter.m
+++ b/Pod/Classes/ArtsyAuthenticationRouter.m
@@ -39,7 +39,10 @@
     if (self.xappToken) {
         [request setValue:self.xappToken.token forHTTPHeaderField:@"X-Xapp-Token"];
     }
-
+    if (self.authToken) {
+        [request setValue:self.authToken.token forHTTPHeaderField:@"X-Access-Token"];
+    }
+    
     return [request copy];
 }
 
@@ -59,6 +62,11 @@
 
     NSURL *url = [[self urlWithPath:@"/oauth2/access_token"] uq_URLByAppendingQueryDictionary:params];
     return [self baseRequestForAddress:url];
+}
+
+- (NSURLRequest *)requestForUserDetails;
+{
+    return [self baseRequestForAddress:[self urlWithPath:@"/api/v1/me"]];
 }
 
 - (NSURLRequest *)requestForCreateNewUserwithEmail:(NSString *)email name:(NSString *)name password:(NSString *)password {
@@ -83,7 +91,6 @@
     NSURL *url = [[self urlWithPath:@"/api/v1/user"] uq_URLByAppendingQueryDictionary:params];
     return [self baseRequestForAddress:url method:@"POST"];
 }
-
 
 - (NSURLRequest *)newFacebookOAuthRequestWithToken:(NSString *)facebookToken {
     NSDictionary *params = @{
@@ -138,3 +145,4 @@
 }
 
 @end
+


### PR DESCRIPTION
In Emission we need an access token and the user’s ID, the latter is now covered by the extra fetch.

Alas I wasn’t able to get the Swift test setup to run and add tests. If someone more experience with Swift+Xcode could take a stab at making it green I’ll gladly add the required tests.
